### PR TITLE
Align logback with sisu.inject

### DIFF
--- a/org.eclipse.sisu.plexus.tests/pom.xml
+++ b/org.eclipse.sisu.plexus.tests/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.7</version>
+      <version>1.1.11</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Was 1.0.7 here vs 1.1.11 in sisu.inject, went with higher.