### PR TITLE
Basic support for Path parameters using default file-system

### DIFF
--- a/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/basic/PathConverter.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/basic/PathConverter.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023-present Sonatype, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Stuart McCulloch - initial API and implementation
+ *
+ * Minimal facade required to be binary-compatible with legacy Plexus API
+ *******************************************************************************/
+package org.codehaus.plexus.component.configurator.converters.basic;
+
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public class PathConverter
+    extends FileConverter
+{
+    public boolean canConvert( final Class<?> type )
+    {
+        return Path.class.equals( type );
+    }
+
+    @Override
+    public Object fromConfiguration( final ConverterLookup lookup, final PlexusConfiguration configuration,
+                                     final Class<?> type, final Class<?> enclosingType, final ClassLoader loader,
+                                     final ExpressionEvaluator evaluator, final ConfigurationListener listener )
+        throws ComponentConfigurationException
+    {
+        final Object result =
+            super.fromConfiguration( lookup, configuration, type, enclosingType, loader, evaluator, listener );
+
+        return result instanceof File ? ( (File) result ).toPath() : result;
+    }
+}

--- a/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/lookup/DefaultConverterLookup.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/lookup/DefaultConverterLookup.java
@@ -28,6 +28,7 @@ import org.codehaus.plexus.component.configurator.converters.basic.FileConverter
 import org.codehaus.plexus.component.configurator.converters.basic.FloatConverter;
 import org.codehaus.plexus.component.configurator.converters.basic.IntConverter;
 import org.codehaus.plexus.component.configurator.converters.basic.LongConverter;
+import org.codehaus.plexus.component.configurator.converters.basic.PathConverter;
 import org.codehaus.plexus.component.configurator.converters.basic.ShortConverter;
 import org.codehaus.plexus.component.configurator.converters.basic.StringBufferConverter;
 import org.codehaus.plexus.component.configurator.converters.basic.StringBuilderConverter;
@@ -58,6 +59,7 @@ public final class DefaultConverterLookup
         new PropertiesConverter(), //
         new UrlConverter(), //
         new UriConverter(), //
+        new PathConverter(), //
         new DateConverter(), //
         new EnumConverter(), //
         new LongConverter(), //


### PR DESCRIPTION
I'm still struggling to find a clean way to handle the non-default file-system case, so splitting this less controversial piece out for merging first.

The main issue with non-default file-systems is how to handle clean-up when the converter needs to implicitly create the file-system. The converter doesn't really have a lifecycle and the JDK doc states that if you do clean-up a file-system instance then you may not be able to create another instance with the same name. We could clean them up when the container is disposed, but that wouldn't work for long-lived containers in IDEs. I'm leaning towards just having the converter use named file-system instances, and leaving management of them to another component - just need to create some examples to see how that might work in practice.