### PR TITLE
Undo unrelated change

### DIFF
--- a/org.eclipse.sisu.plexus/src/main/java/org/eclipse/sisu/plexus/CompositeBeanHelper.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/eclipse/sisu/plexus/CompositeBeanHelper.java
@@ -264,7 +264,7 @@ public final class CompositeBeanHelper
                                             listener );
     }
 
-    private Method findMethod( final Class<?> beanType, final Type[] paramTypeHolder, final String methodName,
+    private static Method findMethod( final Class<?> beanType, final Type[] paramTypeHolder, final String methodName,
                                final Class<?> valueType )
     {
         Method candidate = null;


### PR DESCRIPTION
And is inconsistent, as then why only this one private static method, why not all? These methods are fine to remain static as they do not depend on any instance variable. Lets undo this change (and have them all static) or, we can make them all instance methods, but remain
consistent.